### PR TITLE
Add test to verify unique encrypted values

### DIFF
--- a/vault/barrier_aes_gcm_test.go
+++ b/vault/barrier_aes_gcm_test.go
@@ -102,3 +102,29 @@ func TestAESGCMBarrier_Integrity(t *testing.T) {
 		t.Fatalf("should fail!")
 	}
 }
+
+func TestEncrypt_Unique(t *testing.T) {
+	inm := physical.NewInmem()
+	b, err := NewAESGCMBarrier(inm)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	key, _ := b.GenerateKey()
+	b.Initialize(key)
+	b.Unseal(key)
+
+	entry := &Entry{Key: "test", Value: []byte("test")}
+	primary := b.primary
+
+	if primary == nil {
+		t.Fatalf("Barrier Sealed")
+	}
+
+	first := b.encrypt(primary, entry.Value)
+	second := b.encrypt(primary, entry.Value)
+
+	if (bytes.Equal(first, second) == true) {
+		t.Fatalf("Improper Random Seeding Detected")
+	}
+}


### PR DESCRIPTION
It wasn't immediately clear that the proper random seeding was taking
place. This ensures that the same plaintext encrypted twice does not
result in the same ciphertext. It will also be a good test to keep
around incase of future regressions.